### PR TITLE
Fix HTML rendering to handle nil values without removing sibling elements

### DIFF
--- a/src/dompa/nodes.cljc
+++ b/src/dompa/nodes.cljc
@@ -38,7 +38,7 @@
           (let [value (nodes->html-fn (-> node :node/children))]
             (str html "<" node-name node-attrs ">" value "</" node-name ">"))))
 
-      :else "")))
+      :else html)))
 
 (defn traverse
   "Recursively traverses given tree of `nodes` with a `traverser-fn`
@@ -149,7 +149,10 @@
 
 (defn- nodes-from-opt
   [opt]
-  (cond (map? opt)
+  (cond (nil? opt)
+        nil
+
+        (map? opt)
         opt
 
         (empty-seq? opt)
@@ -157,7 +160,7 @@
 
         (list-of-many? opt)
         {:node/name :<>
-         :node/children opt}
+         :node/children (remove nil? opt)}
 
         (list-of-one? opt)
         (first opt)
@@ -176,7 +179,9 @@
         children-opts (if attrs? (drop 2 opts) (rest opts))
         children-nodes (->> children-opts
                             (map nodes-from-opt)
-                            flatten)]
+                            flatten
+                            (remove nil?)
+                            vec)]
     (cond-> {:node/name first-opt}
       attrs? (assoc :node/attrs attrs)
       (seq children-nodes) (assoc :node/children children-nodes))))

--- a/test/dompa/nodes_test.cljc
+++ b/test/dompa/nodes_test.cljc
@@ -130,6 +130,44 @@
                                              ($ x))
                                            ["l" "d"])])]))))))
 
+(deftest nil-in-hierarchy-does-not-remove-siblings-test
+  (testing "nil in a fragment should not remove sibling elements"
+    (is (= "<div>one</div><div>two</div>"
+           (nodes/->html
+            [($ :<>
+                ($ :div "one")
+                ($ :div "two")
+                nil)]))))
+
+  (testing "nil between siblings should not affect them"
+    (is (= "<div>one</div><div>two</div>"
+           (nodes/->html
+            [($ :<>
+                ($ :div "one")
+                nil
+                ($ :div "two"))]))))
+
+  (testing "multiple nils should not affect siblings"
+    (is (= "<div>one</div><div>two</div><div>three</div>"
+           (nodes/->html
+            [($ :<>
+                nil
+                ($ :div "one")
+                nil
+                ($ :div "two")
+                nil
+                ($ :div "three")
+                nil)]))))
+
+  (testing "nil inside nested element should not affect parent siblings"
+    (is (= "<div><span>hello</span></div><div>world</div>"
+           (nodes/->html
+            [($ :<>
+                ($ :div
+                   ($ :span "hello")
+                   nil)
+                ($ :div "world"))])))))
+
 (deftest traverse-test
   (let [traverser-fn (fn [node]
                        (if (= :dompa/text (:node/name node))


### PR DESCRIPTION
This pull request improves the handling of `nil` values in node hierarchies within the `dompa` library, ensuring that `nil` entries do not inadvertently remove or affect sibling nodes when converting node trees to HTML. It also adds comprehensive tests to verify this behavior.

**Nil handling improvements:**

* Updated `nodes-from-opt` in `src/dompa/nodes.cljc` to explicitly handle `nil` values, ensuring they do not propagate into node children lists.
* Modified node construction logic in `src/dompa/nodes.cljc` to remove `nil` children and ensure the children vector only contains valid nodes.
* Changed the HTML rendering fallback in `nodes->html-fn` to return the current `html` string instead of an empty string for unmatched cases, preventing accidental removal of siblings when encountering `nil`.

**Testing improvements:**

* Added `nil-in-hierarchy-does-not-remove-siblings-test` in `test/dompa/nodes_test.cljc` to verify that `nil` values do not affect sibling elements or their HTML output in various scenarios.